### PR TITLE
Get IPU6 working on Arch linux

### DIFF
--- a/arch/etc/dracut/51-swsnr-xps-9315.conf
+++ b/arch/etc/dracut/51-swsnr-xps-9315.conf
@@ -1,0 +1,6 @@
+# Dracut configuration for XPS 9315.
+
+# Omit extra (out-of-tree) kernel modules; this keeps including the intel ipu6
+# modules and their dependencies, but fails to include all relevant firmware, so
+# the modules come up in a broken state.
+omit_dracutmodules+=" kernel-modules-extra "

--- a/arch/etc/dracut/90-swsnr-sbctl.conf
+++ b/arch/etc/dracut/90-swsnr-sbctl.conf
@@ -1,5 +1,3 @@
 # Sign unified images with sbctl keys to support secure boot
 uefi_secureboot_cert="/usr/share/secureboot/keys/db/db.pem"
 uefi_secureboot_key="/usr/share/secureboot/keys/db/db.key"
-# Enable lockdown if secure boot's on to prevent loading unsigned kernel modules
-kernel_cmdline+=" lockdown=integrity "

--- a/arch/install.bash
+++ b/arch/install.bash
@@ -694,6 +694,7 @@ case "$PRODUCT_NAME" in
     'XPS 9315')
         aur_packages+=(
             intel-ipu6ep-camera-hal-git
+            icamerasrc-git
         )
         ;;
 esac

--- a/arch/install.bash
+++ b/arch/install.bash
@@ -269,7 +269,9 @@ case "$PRODUCT_NAME" in
     'XPS 9315')
         packages+=(
             sof-firmware # Firmware for XPS audio devices
-            # We require dkms modules for some hardware, hence we need headers
+        )
+        optdeps+=(
+            # dkms: Build kernel modules
             linux-headers
             linux-zen-headers
         )

--- a/arch/install.bash
+++ b/arch/install.bash
@@ -269,6 +269,9 @@ case "$PRODUCT_NAME" in
     'XPS 9315')
         packages+=(
             sof-firmware # Firmware for XPS audio devices
+            # We require dkms modules for some hardware, hence we need headers
+            linux-headers
+            linux-zen-headers
         )
         ;;
 esac
@@ -684,6 +687,14 @@ aur_packages=(
     # See <https://bugs.archlinux.org/task/60210>
     texlive-latexindent-meta
 )
+
+case "$PRODUCT_NAME" in
+    'XPS 9315')
+        aur_packages+=(
+            intel-ipu6ep-camera-hal-git
+        )
+        ;;
+esac
 
 case "$HOSTNAME" in
     *kastl*)

--- a/arch/install.bash
+++ b/arch/install.bash
@@ -484,6 +484,13 @@ else
     rm -f /etc/dracut.conf.d/90-swsnr-sbctl.conf
 fi
 
+case "$PRODUCT_NAME" in
+    'XPS 9315')
+        install -pm644 -t /etc/dracut.conf.d/ \
+            "$DIR"/etc/dracut/51-swsnr-xps-9315.conf
+        ;;
+esac
+
 # Boot loader configuration
 case "$HOSTNAME" in
     *kastl*)


### PR DESCRIPTION
## TODO

- [ ] Broken symlink: https://aur.archlinux.org/packages/intel-ipu6ep-camera-hal-git#comment-893085
- [ ] Missing dependencies: https://aur.archlinux.org/packages/icamerasrc-git#comment-893081

## Ugly

- Lookdown needs to be turned off: https://github.com/swsnr/dotfiles/pull/1/files#diff-8a8275a10a5c7a1b2c136ed02e049fd398c7a3ef8e10755f2edcb40bf014402f
- Dracut keeps including the modules in the initrd but without necessary firmware:  https://github.com/swsnr/dotfiles/pull/1/files#diff-e24b4c259569a9d02287e1c8a26f62f0eebd7fa6b05160316ab1351aaab24a20